### PR TITLE
update min versions: carbon2 and php7.1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Prerequisites
 
-WP_Queue requires PHP __5.3+__.
+WP_Queue requires PHP __7.1.8+__.
 
 The following database tables need to be created:
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "nesbot/carbon": "^1.22"
+        "nesbot/carbon": "^2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": "^7.1.8",
         "nesbot/carbon": "^2"
     },
     "autoload": {


### PR DESCRIPTION
carbon1 is deprecated

NOTE: I have pulled in the changes from PR#5 into a seperate branch in my fork called develop.  There was a merge conflict in composer.json.  If you want to accept PR#5, I can create a separate pull request from the the develop branch.