### PR TITLE
Add ability to restrict allowed job subclasses

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ end_of_line = lf
 indent_size = 4
 tab_width = 4
 indent_style = tab
-insert_final_newline = false
+insert_final_newline = true
 trim_trailing_whitespace = true
 
 [*.txt]

--- a/src/WP_Queue/Connections/ConnectionInterface.php
+++ b/src/WP_Queue/Connections/ConnectionInterface.php
@@ -36,7 +36,7 @@ interface ConnectionInterface {
 	 *
 	 * @param Job $job
 	 */
-	public function release( $job );
+	public function release( Job $job );
 
 	/**
 	 * Push a job onto the failure queue.

--- a/src/WP_Queue/Connections/DatabaseConnection.php
+++ b/src/WP_Queue/Connections/DatabaseConnection.php
@@ -4,7 +4,6 @@ namespace WP_Queue\Connections;
 
 use Carbon\Carbon;
 use Exception;
-use wpdb;
 use WP_Queue\Exceptions\InvalidJobTypeException;
 use WP_Queue\Job;
 
@@ -15,7 +14,7 @@ use WP_Queue\Job;
 class DatabaseConnection implements ConnectionInterface {
 
 	/**
-	 * @var wpdb
+	 * @var \wpdb
 	 */
 	protected $database;
 
@@ -37,7 +36,7 @@ class DatabaseConnection implements ConnectionInterface {
 	/**
 	 * DatabaseQueue constructor.
 	 *
-	 * @param wpdb  $wpdb
+	 * @param \wpdb $wpdb
 	 * @param array $allowed_job_classes Job classes that may be handled, default any Job subclass.
 	 */
 	public function __construct( $wpdb, array $allowed_job_classes = [] ) {

--- a/src/WP_Queue/Connections/DatabaseConnection.php
+++ b/src/WP_Queue/Connections/DatabaseConnection.php
@@ -4,12 +4,13 @@ namespace WP_Queue\Connections;
 
 use Carbon\Carbon;
 use Exception;
+use wpdb;
 use WP_Queue\Job;
 
 class DatabaseConnection implements ConnectionInterface {
 
 	/**
-	 * @var \wpdb
+	 * @var wpdb
 	 */
 	protected $database;
 
@@ -26,7 +27,7 @@ class DatabaseConnection implements ConnectionInterface {
 	/**
 	 * DatabaseQueue constructor.
 	 *
-	 * @param \wpdb $wpdb
+	 * @param wpdb $wpdb
 	 */
 	public function __construct( $wpdb ) {
 		$this->database       = $wpdb;
@@ -111,7 +112,7 @@ class DatabaseConnection implements ConnectionInterface {
 	 *
 	 * @return bool
 	 */
-	public function release( $job ) {
+	public function release( Job $job ) {
 		$data  = [
 			'job'         => serialize( $job ),
 			'attempts'    => $job->attempts(),
@@ -158,7 +159,7 @@ class DatabaseConnection implements ConnectionInterface {
 	 * @return int
 	 */
 	public function jobs() {
-		$sql = "SELECT COUNT(*) FROM {$this->jobs_table}";
+		$sql = "SELECT COUNT(*) FROM $this->jobs_table";
 
 		return (int) $this->database->get_var( $sql );
 	}
@@ -169,7 +170,7 @@ class DatabaseConnection implements ConnectionInterface {
 	 * @return int
 	 */
 	public function failed_jobs() {
-		$sql = "SELECT COUNT(*) FROM {$this->failures_table}";
+		$sql = "SELECT COUNT(*) FROM $this->failures_table";
 
 		return (int) $this->database->get_var( $sql );
 	}
@@ -179,7 +180,7 @@ class DatabaseConnection implements ConnectionInterface {
 	 *
 	 * @param Job $job
 	 */
-	protected function reserve( $job ) {
+	protected function reserve( Job $job ) {
 		$data = [
 			'reserved_at' => $this->datetime(),
 		];
@@ -255,5 +256,4 @@ class DatabaseConnection implements ConnectionInterface {
 
 		return $string;
 	}
-
 }

--- a/src/WP_Queue/Connections/RedisConnection.php
+++ b/src/WP_Queue/Connections/RedisConnection.php
@@ -5,6 +5,12 @@ namespace WP_Queue\Connections;
 use Exception;
 use WP_Queue\Job;
 
+/**
+ * An incomplete example of how a new ConnectionInterface could be set up
+ * for storing queue jobs.
+ *
+ * Please see the DatabaseConnection class for a complete working implementation.
+ */
 class RedisConnection implements ConnectionInterface {
 
 	/**

--- a/src/WP_Queue/Connections/RedisConnection.php
+++ b/src/WP_Queue/Connections/RedisConnection.php
@@ -16,6 +16,7 @@ class RedisConnection implements ConnectionInterface {
 	 * @return bool|int
 	 */
 	public function push( Job $job, $delay = 0 ) {
+		return false;
 	}
 
 	/**
@@ -24,22 +25,29 @@ class RedisConnection implements ConnectionInterface {
 	 * @return bool|Job
 	 */
 	public function pop() {
+		return false;
 	}
 
 	/**
 	 * Delete a job from the queue.
 	 *
 	 * @param Job $job
+	 *
+	 * @return bool
 	 */
 	public function delete( $job ) {
+		return false;
 	}
 
 	/**
 	 * Release a job back onto the queue.
 	 *
 	 * @param Job $job
+	 *
+	 * @return bool
 	 */
-	public function release( $job ) {
+	public function release( Job $job ) {
+		return false;
 	}
 
 	/**
@@ -51,6 +59,7 @@ class RedisConnection implements ConnectionInterface {
 	 * @return bool
 	 */
 	public function failure( $job, Exception $exception ) {
+		return false;
 	}
 
 	/**
@@ -59,6 +68,7 @@ class RedisConnection implements ConnectionInterface {
 	 * @return int
 	 */
 	public function jobs() {
+		return 0;
 	}
 
 	/**
@@ -67,6 +77,6 @@ class RedisConnection implements ConnectionInterface {
 	 * @return int
 	 */
 	public function failed_jobs() {
+		return 0;
 	}
-
 }

--- a/src/WP_Queue/Connections/SyncConnection.php
+++ b/src/WP_Queue/Connections/SyncConnection.php
@@ -6,6 +6,7 @@ use Exception;
 use WP_Queue\Job;
 
 class SyncConnection implements ConnectionInterface {
+
 	/**
 	 * Execute the job immediately without pushing to the queue.
 	 *
@@ -47,7 +48,7 @@ class SyncConnection implements ConnectionInterface {
 	 *
 	 * @return bool
 	 */
-	public function release( $job ) {
+	public function release( Job $job ) {
 		return false;
 	}
 

--- a/src/WP_Queue/Connections/SyncConnection.php
+++ b/src/WP_Queue/Connections/SyncConnection.php
@@ -5,6 +5,12 @@ namespace WP_Queue\Connections;
 use Exception;
 use WP_Queue\Job;
 
+/**
+ * A minimal implementation of the ConnectionInterface that handles a pushed
+ * Job immediately.
+ *
+ * Useful for local development when only wanting to debug how Job items are handled.
+ */
 class SyncConnection implements ConnectionInterface {
 
 	/**

--- a/src/WP_Queue/Exceptions/InvalidJobTypeException.php
+++ b/src/WP_Queue/Exceptions/InvalidJobTypeException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace WP_Queue\Exceptions;
+
+use Exception;
+
+/**
+ * Exception for when job data includes an unrecognized class.
+ */
+class InvalidJobTypeException extends Exception {
+}

--- a/src/WP_Queue/QueueManager.php
+++ b/src/WP_Queue/QueueManager.php
@@ -2,6 +2,8 @@
 
 namespace WP_Queue;
 
+use Exception;
+use WP_Queue\Connections\ConnectionInterface;
 use WP_Queue\Connections\DatabaseConnection;
 use WP_Queue\Connections\RedisConnection;
 use WP_Queue\Connections\SyncConnection;
@@ -18,28 +20,30 @@ class QueueManager {
 	 * Resolve a Queue instance for required connection.
 	 *
 	 * @param string $connection
+	 * @param array  $allowed_job_classes Job classes that may be handled, default any Job subclass.
 	 *
 	 * @return Queue
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	public static function resolve( $connection ) {
+	public static function resolve( $connection, array $allowed_job_classes = [] ) {
 		if ( isset( static::$instances[ $connection ] ) ) {
 			return static::$instances[ $connection ];
 		}
 
-		return static::build( $connection );
+		return static::build( $connection, $allowed_job_classes );
 	}
 
 	/**
 	 * Build a queue instance.
 	 *
 	 * @param string $connection
+	 * @param array  $allowed_job_classes Job classes that may be handled, default any Job subclass.
 	 *
 	 * @return Queue
-	 * @throws \Exception
+	 * @throws Exception
 	 */
-	protected static function build( $connection ) {
-		$connections = static::connections();
+	protected static function build( $connection, array $allowed_job_classes = [] ) {
+		$connections = static::connections( $allowed_job_classes );
 
 		if ( empty( $connections[ $connection ] ) ) {
 			throw new ConnectionNotFoundException();
@@ -53,15 +57,26 @@ class QueueManager {
 	/**
 	 * Get available connections.
 	 *
+	 * It's strongly recommended to override this function and provide a unique
+	 * set of connections for your plugin, and unique filter name if filtering
+	 * is desired.
+	 *
+	 * @param array $allowed_job_classes Job classes that may be handled, default any Job subclass.
+	 *
 	 * @return array
 	 */
-	protected static function connections() {
+	protected static function connections( array $allowed_job_classes = [] ) {
 		$connections = [
-			'database' => new DatabaseConnection( $GLOBALS['wpdb'] ),
+			'database' => new DatabaseConnection( $GLOBALS['wpdb'], $allowed_job_classes ),
 			'redis'    => new RedisConnection(),
 			'sync'     => new SyncConnection(),
 		];
 
+		/**
+		 * Filter the available connections.
+		 *
+		 * @param ConnectionInterface[] $connections Associative array of connections.
+		 */
 		return apply_filters( 'wp_queue_connections', $connections );
 	}
 }

--- a/src/WP_Queue/Worker.php
+++ b/src/WP_Queue/Worker.php
@@ -3,6 +3,7 @@
 namespace WP_Queue;
 
 use Exception;
+use WP_Queue\Connections\ConnectionInterface;
 use WP_Queue\Exceptions\WorkerAttemptsExceededException;
 
 class Worker {

--- a/src/functions.php
+++ b/src/functions.php
@@ -8,16 +8,17 @@ if ( ! function_exists( 'wp_queue' ) ) {
 	 * Return Queue instance.
 	 *
 	 * @param string $connection
+	 * @param array  $allowed_job_classes Job classes that may be handled. Default, any Job subclass.
 	 *
 	 * @return Queue
 	 * @throws Exception
 	 */
-	function wp_queue( $connection = '' ) {
+	function wp_queue( $connection = '', array $allowed_job_classes = [] ) {
 		if ( empty( $connection ) ) {
 			$connection = apply_filters( 'wp_queue_default_connection', 'database' );
 		}
 
-		return QueueManager::resolve( $connection );
+		return QueueManager::resolve( $connection, $allowed_job_classes );
 	}
 }
 

--- a/tests/TestQueueManager.php
+++ b/tests/TestQueueManager.php
@@ -2,12 +2,13 @@
 
 use PHPUnit\Framework\TestCase;
 use WP_Queue\Exceptions\ConnectionNotFoundException;
+use WP_Queue\Job;
 use WP_Queue\Queue;
 use WP_Queue\QueueManager;
 
 class TestQueueManager extends TestCase {
 
-	public function setUp() : void {
+	public function setUp(): void {
 		WP_Mock::setUp();
 
 		global $wpdb;
@@ -15,19 +16,28 @@ class TestQueueManager extends TestCase {
 		$wpdb->prefix = 'wp_';
 	}
 
-	public function tearDown() : void {
+	public function tearDown(): void {
 		WP_Mock::tearDown();
 	}
 
 	public function test_resolve() {
 		$queue = QueueManager::resolve( 'database' );
 		$this->assertInstanceOf( Queue::class, $queue );
-		$queue = QueueManager::resolve( 'database' );
+		$queue = QueueManager::resolve( 'database', [] );
+		$this->assertInstanceOf( Queue::class, $queue );
+		$queue = QueueManager::resolve( 'database', [ TestJob::class ] );
 		$this->assertInstanceOf( Queue::class, $queue );
 	}
 
 	public function test_resolve_exception() {
 		$this->expectException( ConnectionNotFoundException::class );
 		QueueManager::resolve( 'wibble' );
+	}
+}
+
+if ( ! class_exists( 'TestJob' ) ) {
+	class TestJob extends Job {
+		public function handle() {
+		}
 	}
 }


### PR DESCRIPTION
When a `Job` is popped off the queue, it is now checked to make sure it is a subclass of `Job`.

It is now possible to specify the `Job` subclasses that can be handled by a `DatabaseConnection`.

If `Job` data is found in the queue that is either not a `Job` subclass or not part of the optionally specified list of allowed `Job` subclasses, then `Cron` or `Worker` will refuse to process the `Job`, and it will be failed as an `InvalidJobTypeException`.